### PR TITLE
feat: add eslint and related libraries (#2)

### DIFF
--- a/libs/base/package.json
+++ b/libs/base/package.json
@@ -14,8 +14,9 @@
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
     "eslint": "^8.56.0",
+    "eslint-config-eslint": "^9.0.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-jsdoc": "^48.0.4",
+    "globals": "^13.24.0",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {

--- a/libs/base/package.json
+++ b/libs/base/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@shinGangan/eslint-configs",
+  "version": "0.0.1",
+  "description": "ESLint config for base presets",
+  "private": true,
+  "author": "shinGangan",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shinGangan/eslint-configs.git",
+    "directory": "packages/base"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.19.1",
+    "@typescript-eslint/parser": "^6.19.1",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-jsdoc": "^48.0.4",
+    "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "eslint": ">=8.23.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@shinGangan/eslint-configs",
+  "version": "0.0.1",
+  "description": "ESLint config for presets",
+  "private": true,
+  "author": "shinGangan",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shinGangan/eslint-configs.git"
+  },
+  "packageManager": "pnpm@8.14.0",
+  "devDependencies": {
+    "changelogen": "^0.5.5",
+    "prettier": "^3.2.4",
+    "prettier-plugin-organize-imports": "^3.2.4"
+  }
+}


### PR DESCRIPTION
## Issue

closed #2 .

## Context

- [x] add `eslint` and related libraries
  - [x] `eslint` : `v8.56.0`
  - [x] `eslint-config-eslint` : `v8.56.0`
    以下は内部でインストールされている
    - `@eslint/js`
    - `eslint-plugin-eslint-comments`
    - `eslint-plugin-jsdoc`
    - `eslint-plugin-n`
    - `eslint-plugin-unicorn`
  - [x] `eslint-config-prettier`
  - [x] `typescript`
  - [x] `@typescript-eslint/eslint-plugin`
  - [x] `@typescript-eslint/parser`
- [x] add related Flat Config libraries
  - [x] `globals`

### Related

- #5 
- #3 

### Ref

[`@eslint/eslintrc`](https://www.npmjs.com/package/@eslint/eslintrc) は現在凍結しているみたい。別途調査する必要がある。

=> [`eslint-config-eslint`](https://github.com/eslint/eslint/tree/c25b4aff1fe35e5bd9d4fcdbb45b739b6d253828/packages/eslint-config-eslint) に移行していた

## Reviewer checklist

- [ ]
