### PR TITLE
fix: Cannot find preset's package (github>shinGangan/renovate-config//configs/linters/recommended)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>shinGangan/renovate-config",
-    "github>shinGangan/renovate-config//configs/linters/recommended",
+    "github>shinGangan/renovate-config//configs/linters",
     ":dependencyDashboard",
   ],
   "reviewers": ["shinGangan"]


### PR DESCRIPTION
## Issue

closed #11 .

## Context

- [x] `Cannot find preset's package (github>shinGangan/renovate-config//configs/linters/recommended)` エラー対応

## Ref 

- https://github.com/shinGangan/renovate-config